### PR TITLE
Make WeDeploy button work

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Deploy](https://cdn.wedeploy.com/images/deploy.svg)](https://console.wedeploy.com/deploy?repo=https://github.com/wedeploy/owncloud-example)
+[![Deploy](https://cdn.wedeploy.com/images/deploy.svg)](https://console.wedeploy.com/deploy?repo=https://github.com/wedeploy-examples/owncloud-example)
 
 # OwnCloud
 


### PR DESCRIPTION
The WeDeploy one click button is currently broken. This patch fixes that problem by reconfiguring the repository URL in the button.